### PR TITLE
styled-views-android-33 Touch override interferes with callbacks for slider

### DIFF
--- a/app-demo/src/main/java/co/sodalabs/demo/StyledSliderViewDemo.kt
+++ b/app-demo/src/main/java/co/sodalabs/demo/StyledSliderViewDemo.kt
@@ -3,7 +3,6 @@ package co.sodalabs.demo
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.widget.SeekBar
-import co.sodalabs.view.IStyledSliderListener
 import kotlinx.android.synthetic.main.activity_demo_styled_slider.buttonAddSlMarker
 import kotlinx.android.synthetic.main.activity_demo_styled_slider.buttonAddSlNormal
 import kotlinx.android.synthetic.main.activity_demo_styled_slider.buttonSubtractSlMarker
@@ -48,12 +47,7 @@ class StyledSliderViewDemo : AppCompatActivity() {
         updateNormalSeekbarLabels(slNormal)
         updateMarkerSeekbarLabels(slMarker)
 
-        slNormal.setOnSeekBarChangeListener(object : IStyledSliderListener {
-            override fun onMarkerLevelUpdated(seekBar: SeekBar, markerLevel: Int) {
-                println("onMarkerLevelUpdated, markerLevel=$markerLevel")
-                updateNormalSeekbarLabels(seekBar)
-            }
-
+        slNormal.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                 println("onProgressChanged, progress=$progress")
                 updateNormalSeekbarLabels(seekBar)
@@ -68,12 +62,7 @@ class StyledSliderViewDemo : AppCompatActivity() {
             }
         })
 
-        slMarker.setOnSeekBarChangeListener(object : IStyledSliderListener {
-            override fun onMarkerLevelUpdated(seekBar: SeekBar, markerLevel: Int) {
-                println("onMarkerLevelUpdated, markerLevel=$markerLevel")
-                updateMarkerSeekbarLabels(seekBar)
-            }
-
+        slMarker.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                 println("onProgressChanged, progress=$progress")
                 updateMarkerSeekbarLabels(seekBar)

--- a/styled-slider-view/src/main/java/co/sodalabs/view/IStyledSliderListener.kt
+++ b/styled-slider-view/src/main/java/co/sodalabs/view/IStyledSliderListener.kt
@@ -1,8 +1,0 @@
-package co.sodalabs.view
-
-import android.widget.SeekBar
-
-interface IStyledSliderListener : SeekBar.OnSeekBarChangeListener {
-
-    fun onMarkerLevelUpdated(seekBar: SeekBar, markerLevel: Int)
-}


### PR DESCRIPTION
The source of all the problems was hardcoded value of 100 that was being used in place of `max`. Correcting it not only fixed the `progress` related bugs but also eliminated the need for the custom solution for Snapping of font slider. The default behavior of Android's `SeekBar` is to snap to the nearest values, the effect is only noticeable when the `max` value is small enough. 

This PR mostly contains clean up for stuff that is no longer required.

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/6507679/50763714-8ca76900-12ab-11e9-8fc3-04052c9f7868.gif)
